### PR TITLE
Bugfixes for compota 0.9.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "com.novocode"   % "junit-interface" % "0.10" % "test",
   "org.clapper"   %% "avsl" % "1.0.1",
   "org.json4s"    %% "json4s-native" % "3.2.5",
-  "ohnosequences" %% "aws-scala-tools" % "0.8.1-SNAPSHOT",
+  "ohnosequences" %% "aws-scala-tools" % "0.13.2",
   "ohnosequences" %% "statika" % "1.0.0",
   "ohnosequences" %% "aws-statika" % "1.0.1",
   "ohnosequences" %% "amazon-linux-ami" % "0.14.1",
@@ -35,7 +35,7 @@ resolvers +=  Resolver.url("era7" + " public ivy releases",  url("http://release
 resolvers +=  Resolver.url("era7" + " public ivy snapshots",  url("http://snapshots.era7.com.s3.amazonaws.com"))(Resolver.ivyStylePatterns)
 
 
-dependencyOverrides += "ohnosequences" % "aws-scala-tools_2.10" % "0.8.1-SNAPSHOT"
+dependencyOverrides += "ohnosequences" % "aws-scala-tools_2.10" % "0.13.2"
 
 dependencyOverrides += "ohnosequences" % "aws-statika_2.10" % "1.0.1"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.7

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,1 +1,3 @@
 bucketSuffix := "era7.com"
+
+s3overwrite := true

--- a/src/main/scala/ohnosequences/nisperon/AWS.scala
+++ b/src/main/scala/ohnosequences/nisperon/AWS.scala
@@ -7,7 +7,6 @@ import ohnosequences.awstools.autoscaling.AutoScaling
 import ohnosequences.awstools.sqs.SQS
 import ohnosequences.awstools.sns.SNS
 import ohnosequences.awstools.s3.S3
-import ohnosequences.awstools.dynamodb.DynamoDB
 import ohnosequences.awstools.regions.Region.Ireland
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import java.io.File
@@ -45,7 +44,7 @@ class AWS(credentialsFile: File, region: ohnosequences.awstools.regions.Region =
 
  // val ddb = DynamoDB.create(credentialsProvider)
   val ddb = new AmazonDynamoDBClient(credentialsProvider)
-  ddb.setRegion(region)
+  ddb.setRegion(com.amazonaws.regions.Region.getRegion(region))
 }
 
 

--- a/src/main/scala/ohnosequences/nisperon/Configuration.scala
+++ b/src/main/scala/ohnosequences/nisperon/Configuration.scala
@@ -11,7 +11,7 @@ import ohnosequences.nisperon.queues.SQSQueue
 object NisperonConfiguration {
 
   val defaultInstanceSpecs = InstanceSpecs(
-    instanceType = InstanceType.T1Micro,
+    instanceType = InstanceType.t1_micro,
     amiId = "",
     securityGroups = List("nispero"),
     keyName = "nispero",
@@ -85,7 +85,7 @@ abstract class GroupConfiguration {
 }
 
 case class SingleGroup(
-  instanceType: InstanceType = InstanceType.T1Micro,
+  instanceType: InstanceType = InstanceType.t1_micro,
   purchaseModel: PurchaseModel = OnDemand
 ) extends GroupConfiguration {
   val min = 1
@@ -94,7 +94,7 @@ case class SingleGroup(
 }
 
 case class Group(
-  instanceType: InstanceType = InstanceType.T1Micro,
+  instanceType: InstanceType = InstanceType.t1_micro,
   min: Int = 0,
   max: Int = 10,
   size: Int,

--- a/src/main/scala/ohnosequences/nisperon/MetaManager.scala
+++ b/src/main/scala/ohnosequences/nisperon/MetaManager.scala
@@ -157,8 +157,12 @@ class MetaManager(nisperon: Nisperon) {
             } catch {
               case t: Throwable => {
                 if (failTable.fails(m0.id) > nisperonConfiguration.errorThreshold) {
-                  logger.error("message " + m0.id + " failed more than " + nisperonConfiguration.errorThreshold)
-                  m0.delete()
+                  val msg = "message " + m0.id + " failed more than " + nisperonConfiguration.errorThreshold
+                  logger.error(msg)
+                  //m0.delete()
+                  nisperon.undeployActions(true)
+                  writer.write("deleteResources", List(DeleteResources(msg).marshall()))
+                  writer.flush()
                 } else {
                   Nisperon.reportFailure(nisperon.aws, nisperon.nisperonConfiguration, "metamanager", t, terminateInstance = false, failTable = failTable)
                 }

--- a/src/main/scala/ohnosequences/nisperon/Nisperon.scala
+++ b/src/main/scala/ohnosequences/nisperon/Nisperon.scala
@@ -32,8 +32,6 @@ abstract class Nisperon {
 
   val logger = Logger(this.getClass)
 
-  def checks()
-
   class S3Queue[T](name: String, monoid: Monoid[T], serializer: Serializer[T]) extends
   S3QueueAbstract(aws, Naming.s3name(nisperonConfiguration, name), monoid, serializer,
     deadLetterQueueName = nisperonConfiguration.deadLettersQueue) {

--- a/src/main/scala/ohnosequences/nisperon/Nisperon.scala
+++ b/src/main/scala/ohnosequences/nisperon/Nisperon.scala
@@ -15,6 +15,8 @@ import ohnosequences.awstools.ddb.Utils
 import ohnosequences.nisperon.logging.FailTable
 import ohnosequences.nisperon.logging.InstanceLogging
 
+import scala.util.{Success, Failure}
+
 
 abstract class Nisperon {
 
@@ -138,8 +140,14 @@ abstract class Nisperon {
           val failTable =  new FailTable(aws, nisperonConfiguration.errorTable)
           failTable.create()
 
-          if(!aws.s3.objectExists(nisperonConfiguration.artifactAddress)) {
-            throw new Error("jar isn't published: " + nisperonConfiguration.artifactAddress)
+
+          aws.s3.objectExists(nisperonConfiguration.artifactAddress) match {
+            case Failure(t) => {
+              throw new Error("jar isn't published: " + nisperonConfiguration.artifactAddress, t)
+            }
+            case Success(false) => {
+              throw new Error("jar isn't published: " + nisperonConfiguration.artifactAddress)
+            }
           }
 
           logger.info("creating bucket " + nisperonConfiguration.bucket)

--- a/src/main/scala/ohnosequences/nisperon/TerminationDaemon.scala
+++ b/src/main/scala/ohnosequences/nisperon/TerminationDaemon.scala
@@ -6,8 +6,6 @@ import org.clapper.avsl.Logger
 class TerminationDaemon(nisperon: Nisperon) extends Thread {
   val logger = Logger(this.getClass)
 
-
-
   val initLaunchTime = {
 
     var ititTime= 0L

--- a/src/main/scala/ohnosequences/nisperon/queues/DynamoDBQueue.scala
+++ b/src/main/scala/ohnosequences/nisperon/queues/DynamoDBQueue.scala
@@ -8,6 +8,8 @@ import ohnosequences.awstools.ddb.Utils
 import scala.collection.mutable.ListBuffer
 import ohnosequences.nisperon.Tasks
 
+import scala.util.{Success, Failure, Try}
+
 class DynamoDBQueueAbstract[T](
                         aws: AWS,
                         name: String,
@@ -139,13 +141,22 @@ class DynamoDBQueueAbstract[T](
 
 
   def isEmpty: Boolean = {
-    val count = aws.ddb.scan(new ScanRequest()
-      .withTableName(name)
-      .withSelect(Select.COUNT)
-      .withLimit(1)
-    ).getCount
-    println(count)
-    count == 0
+    Try {
+      val count = aws.ddb.scan(new ScanRequest()
+        .withTableName(name)
+        .withSelect(Select.COUNT)
+        .withLimit(1)
+      ).getCount
+      //println(count)
+      count == 0
+    } match {
+      case Failure(t) => {
+        false
+      }
+      case Success(b) => {
+        b
+      }
+    }
   }
 
   def list(): List[String] = {

--- a/src/main/scala/ohnosequences/nisperon/queues/DynamoDBQueue.scala
+++ b/src/main/scala/ohnosequences/nisperon/queues/DynamoDBQueue.scala
@@ -151,6 +151,7 @@ class DynamoDBQueueAbstract[T](
       count == 0
     } match {
       case Failure(t) => {
+        logger.warn("couldn't check emptiness of DynamoDB table " + name)
         false
       }
       case Success(b) => {

--- a/src/main/scala/ohnosequences/nisperon/queues/MonoidQueue.scala
+++ b/src/main/scala/ohnosequences/nisperon/queues/MonoidQueue.scala
@@ -37,8 +37,6 @@ trait MonoidQueueAux {
 
   def sqsQueueInfo(): Option[SQSQueueInfo]
 
-
-
   def isEmpty: Boolean
 
   def list(): List[String]

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.12-RC1"
+version in ThisBuild := "0.9.12-RC2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.12-RC2"
+version in ThisBuild := "0.9.12-RC3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.12-SNAPSHOT"
+version in ThisBuild := "0.9.12-RC1"


### PR DESCRIPTION
This branch contains critical bug fixes for old version of Compota (0.9.12). API and major dependencies (Statika 1.0.0 and Scala 2.10) are not going to be changed.

This Compota version is used by Metapasta 0.9.12
